### PR TITLE
Julia 0.5 support and allowing branch name as commit reference

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,1 @@
-julia 0.4-
+julia 0.4

--- a/bin/jdp
+++ b/bin/jdp
@@ -35,7 +35,7 @@ fi
 # set variables
 if [ `uname` == Darwin ]
 then
-	MD5="md5 -q"    
+	MD5="md5 -q"
 	STAT="stat -f \"%p\""
 	STATVALUE=\"40555\"
 else
@@ -49,7 +49,6 @@ export JULIA_PKGDIR=$HOME/.julia/declarative/$HASH$TESTSUFFIX
 
 # find out where the script is:
 # (thanks to http://stackoverflow.com/questions/59895/can-a-bash-script-tell-what-directory-its-stored-in)
-
 SOURCE="${BASH_SOURCE[0]}"
 while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
   DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
@@ -60,9 +59,9 @@ DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
 
 # install packages if not installled yet
-if [ ! -e $JULIA_PKGDIR/v0.2/REQUIRE ] && [ ! -e $JULIA_PKGDIR/v0.3/REQUIRE ] && [ ! -e $JULIA_PKGDIR/v0.4/REQUIRE ] && [ ! -e $JULIA_PKGDIR/v0.6/REQUIRE ]; 
+if [ ! -e $JULIA_PKGDIR/v0.2/REQUIRE ] && [ ! -e $JULIA_PKGDIR/v0.3/REQUIRE ] && [ ! -e $JULIA_PKGDIR/v0.4/REQUIRE ] && [ ! -e $JULIA_PKGDIR/v0.5/REQUIRE ] && [ ! -e $JULIA_PKGDIR/v0.6/REQUIRE ];
 then
-	DECLARE=$DECLARE $DECLARE_JULIA $DIR/../src/installpackages.jl 
+	DECLARE=$DECLARE $DECLARE_JULIA $DIR/../src/installpackages.jl
 fi
 
 
@@ -71,7 +70,4 @@ HASH=`$MD5 $DECLARE | tr " " "\n" | head -n 1`
 export JULIA_PKGDIR=$HOME/.julia/declarative/$HASH$TESTSUFFIX
 
 # invoke julia
-$DECLARE_JULIA --no-startup -L $DIR/../src/setloadpath.jl "$@"
-	
-
-
+$DECLARE_JULIA --startup-file=no -L $DIR/../src/setloadpath.jl "$@"

--- a/src/installpackages.jl
+++ b/src/installpackages.jl
@@ -66,7 +66,11 @@ function gitclone(name, url, path, commit="")
             if exists(filename)
                 commit = strip(readstring(filename))
             else
-                if commit[1] == 'v'
+                # check if this is a known branch name
+                isbranch = ismatch(Regex(commit), readstring(gitcmd(path, "branch -a")))
+                if isbranch
+                    commit = strip(readstring(gitcmd(path, "rev-parse origin/$commit")))
+                elseif commit[1] == 'v'
                     error("gitclone: Could not find a commit hash for version $commit for package $name ($url)")
                 end
             end

--- a/src/installpackages.jl
+++ b/src/installpackages.jl
@@ -16,7 +16,7 @@ end
 
 function readfile()
     log(1, "Parsing $(ENV["DECLARE"]) ... ")
-    lines = split(readall(ENV["DECLARE"]), '\n')
+    lines = split(readstring(ENV["DECLARE"]), '\n')
     lines = map(x->replace(x, r"#.*", ""), lines)
     lines = filter(x->!isempty(x), lines)
     return lines
@@ -26,7 +26,7 @@ pkgpath(basepath, pkg) = normpath(basepath*"/v$(VERSION.major).$(VERSION.minor)/
 markreadonly(path) = run(`chmod a-w $path`)
 stepout(path, n=1) = normpath(path*"/"*repeat("../",n))
 
-function hardlinkdirs(existingpath, path) 
+function hardlinkdirs(existingpath, path)
     log(3, "hardlinking: existingpath: $existingpath\npath: $path")
     assert(existingpath[end]=='/')
     assert(path[end]=='/')
@@ -37,8 +37,8 @@ function hardlinkdirs(existingpath, path)
         hardlinkdirs(dir[2]*"/", path*dir[1]*"/")
     end
     for file in filter(x->!isdir(x[2]), items)
-        @osx_only ccall((:link, "libc"), Int, (Ptr{UInt8}, Ptr{UInt8}), file[2] , path*file[1])
-        @linux_only ccall((:link, "libc.so.6"), Int, (Ptr{UInt8}, Ptr{UInt8}), file[2] , path*file[1])
+        is_apple() && ccall((:link, "libc"), Int, (Ptr{UInt8}, Ptr{UInt8}), file[2] , path*file[1])
+        is_linux() && ccall((:link, "libc.so.6"), Int, (Ptr{UInt8}, Ptr{UInt8}), file[2] , path*file[1])
     end
 end
 
@@ -48,7 +48,7 @@ function gitcommitof(path)
     log(2, "gitcommitof $path")
     cmd = gitcmd(path, "log -n 1 --format=%H")
     log(2, "gitcommitof cmd $cmd")
-    r = strip(readall(cmd))
+    r = strip(readstring(cmd))
     log(2, "gitcommitof result $r")
     r
 end
@@ -60,11 +60,11 @@ function gitclone(name, url, path, commit="")
         commit = gitcommitof(path)
     else
         # check if the repo knows this commit. if not, check in METADATA
-        isknown = ismatch(Regex(commit), readall(gitcmd(path, "tag")))
+        isknown = ismatch(Regex(commit), readstring(gitcmd(path, "tag")))
         if !isknown
             filename = Pkg.dir("METADATA/$name/versions/$(commit[2:end])/sha1")
             if exists(filename)
-                commit = strip(readall(filename))
+                commit = strip(readstring(filename))
             else
                 if commit[1] == 'v'
                     error("gitclone: Could not find a commit hash for version $commit for package $name ($url)")
@@ -72,7 +72,7 @@ function gitclone(name, url, path, commit="")
             end
         end
     end
-        
+
     run(gitcmd(path, "checkout --force -b pinned.$commit.tmp $commit"))
 end
 
@@ -82,7 +82,7 @@ function existscheckout(pkg, commit)
     dirs = readdir(basepath)
     nontmp = filter(x->length(x)>3 && x[1:4]!="tmp_", dirs)
     for dir in nontmp
-        path = pkgpath(basepath*dir, pkg) 
+        path = pkgpath(basepath*dir, pkg)
         if exists(path) &&  gitcommitof(path) == commit
             log(2, "existscheckout: found $path for $pkg@$commit")
             return path
@@ -130,7 +130,7 @@ function parseline(a)
         isregistered = false
     else
         name = nameorurl
-        url = strip(readall("$(Pkg.dir())/METADATA/$name/url"))
+        url = strip(readstring("$(Pkg.dir())/METADATA/$name/url"))
         isregistered = true
     end
     if name=="METADATA"
@@ -159,10 +159,10 @@ function install(packages::Array)
     linux = filter(x->x.os=="@linux", packages)
     windows = filter(x->x.os=="@windows", packages)
     everywhere = filter(x->x.os=="", packages)
-    @osx_only map(install, osx)
-    @unix_only map(install, unix)
-    @linux_only map(install, linux)
-    @windows_only map(install, windows)
+    is_apple() && map(install, osx)
+    is_unix() && map(install, unix)
+    is_linux() && map(install, linux)
+    is_windows() && map(install, windows)
     needbuilding = filter(x->x!=nothing, map(install, everywhere))
 end
 
@@ -191,8 +191,7 @@ function install(a::Package)
             ""
         end
     end
-    metadatacommit(version) = strip(readall(Pkg.dir("METADATA/$(a.name)/versions/$(version[2:end])/sha1")))
-    
+    metadatacommit(version) = strip(readstring(Pkg.dir("METADATA/$(a.name)/versions/$(version[2:end])/sha1")))
     commit = a.commit == "METADATA" ? latest() : a.commit
     installorlink(a.name, a.url, path, commit)
 end
@@ -213,7 +212,7 @@ function resolve(packages, needbuilding)
             if haskey(ENV, "DECLARE_INCLUDETEST") && ENV["DECLARE_INCLUDETEST"]=="true"
                 testrequire = Pkg.dir(pkg.name*"/test/REQUIRE")
                 if exists(testrequire)
-                    write(io, readall(testrequire))
+                    write(io, readstring(testrequire))
                 end
             end
         end
@@ -227,15 +226,19 @@ end
 function finish()
     exportDECLARE(ENV["DECLARE"])
 
-    @osx_only md5 = strip(readall(`md5 -q $(ENV["DECLARE"])`))
-    @linux_only md5 = strip(readall(`md5sum $(ENV["DECLARE"])`))
+    if is_apple()
+        md5 = strip(readstring(`md5 -q $(ENV["DECLARE"])`))
+    elseif is_linux()
+        md5 = strip(readstring(`md5sum $(ENV["DECLARE"])`))
+    end
+
     md5 = split(md5)[1]
     if haskey(ENV, "DECLARE_INCLUDETEST") && ENV["DECLARE_INCLUDETEST"]=="true"
         md5 = md5*"withtest"
     end
     dir = normpath(Pkg.dir()*"/../../"*md5)
-    
-    if exists(dir) 
+
+    if exists(dir)
         run(`chmod -R a+w $dir`)
         rm(dir; recursive=true)
     end
@@ -251,8 +254,3 @@ function finish()
 end
 
 installpackages()
-
-
-
-
-

--- a/test/listpackages.jl
+++ b/test/listpackages.jl
@@ -1,5 +1,5 @@
 exists(filename::String) = (s = stat(filename); s.inode!=0)
 if exists(Pkg.dir("METADATA"))
-	pkgs = Pkg.installed(); 
-	map(k -> println(k, ' ', pkgs[k]), sort(collect(keys(pkgs))))
+    pkgs = Pkg.installed()
+    map(k -> println(k, ' ', pkgs[k]), sort(collect(keys(pkgs))))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,7 +31,8 @@ function runjdp(file)
     cp(file, tmp)
     ENV["DECLARE"] = tmp
     ENV["DECLARE_VERBOSITY"] = 0
-    r = (readall(`$jdp $listpackages`), readall(tmp))
+    ENV["DECLARE_JULIA"] = joinpath(JULIA_HOME, Base.julia_exename())
+    r = (readstring(`$jdp $listpackages`), readstring(tmp))
     rm(tmp)
     r
 end


### PR DESCRIPTION
This update allows DeclarativePackages.jl to work under the julia 0.5.0 release. It also adds the option to specify a branch name as a commit reference for each package (besides a commit hash and tag name).
