### PR TITLE
Fixes deprecation warnings for Julia 0.5

### DIFF
--- a/bin/jdp
+++ b/bin/jdp
@@ -71,7 +71,7 @@ HASH=`$MD5 $DECLARE | tr " " "\n" | head -n 1`
 export JULIA_PKGDIR=$HOME/.julia/declarative/$HASH$TESTSUFFIX
 
 # invoke julia
-$DECLARE_JULIA --no-startup -L $DIR/../src/setloadpath.jl "$@"
+$DECLARE_JULIA --startup-file=no -L $DIR/../src/setloadpath.jl "$@"
 	
 
 

--- a/src/installpackages.jl
+++ b/src/installpackages.jl
@@ -20,7 +20,7 @@ end
 
 function readfile()
     log(1, "Parsing $(ENV["DECLARE"]) ... ")
-    lines = split(readall(ENV["DECLARE"]), '\n')
+    lines = split(readstring(ENV["DECLARE"]), '\n')
     lines = map(x->replace(x, r"#.*", ""), lines)
     lines = filter(x->!isempty(x), lines)
     return lines
@@ -53,7 +53,7 @@ function gitcommitof(path)
     cmd = gitcmd(path, "log -n 1 --format=%H")
     log(2, "gitcommitof cmd $cmd")
     r = try
-        strip(readall(cmd))
+        strip(readstring(cmd))
     catch
         ""
     end
@@ -65,7 +65,7 @@ function gitcommitoftag(path, tag)
     contains(path, "METADATA") && return ""
     length(tag) > 1 && tag[1] != 'v' && return ""
     cmd = gitcmd(path, "rev-list -n 1 $tag")
-    strip(readall(cmd))
+    strip(readstring(cmd))
 end
 
 function gitclone(name, url, path, commit="")
@@ -75,11 +75,11 @@ function gitclone(name, url, path, commit="")
         commit = gitcommitof(path)
     else
         # check if the repo knows this commit. if not, check in METADATA
-        isknown = ismatch(Regex(commit), readall(gitcmd(path, "tag")))
+        isknown = ismatch(Regex(commit), readstring(gitcmd(path, "tag")))
         if !isknown
             filename = Pkg.dir("METADATA/$name/versions/$(commit[2:end])/sha1")
             if exists(filename)
-                commit = strip(readall(filename))
+                commit = strip(readstring(filename))
             else
                 if commit[1] == 'v'
                     error("gitclone: Could not find a commit hash for version $commit for package $name ($url)")
@@ -151,7 +151,7 @@ function parseline(a)
         isregistered = false
     else
         name = nameorurl
-        url = strip(readall("$(Pkg.dir())/METADATA/$name/url"))
+        url = strip(readstring("$(Pkg.dir())/METADATA/$name/url"))
         isregistered = true
     end
     if name=="METADATA"
@@ -212,8 +212,8 @@ function install(a::Package)
             ""
         end
     end
-    metadatacommit(version) = strip(readall(Pkg.dir("METADATA/$(a.name)/versions/$(version[2:end])/sha1")))
-    
+    metadatacommit(version) = strip(readstring(Pkg.dir("METADATA/$(a.name)/versions/$(version[2:end])/sha1")))
+
     commit = a.commit == "METADATA" ? latest() : a.commit
     installorlink(a.name, a.url, path, commit)
 end
@@ -234,7 +234,7 @@ function resolve(packages, needbuilding)
             if haskey(ENV, "DECLARE_INCLUDETEST") && ENV["DECLARE_INCLUDETEST"]=="true"
                 testrequire = Pkg.dir(pkg.name*"/test/REQUIRE")
                 if exists(testrequire)
-                    write(io, readall(testrequire))
+                    write(io, readstring(testrequire))
                 end
             end
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -47,7 +47,7 @@ test("METADATA2", runjdp("DECLARE.METADATA2"), x->isempty(x[1]))
 test("JSON1", runjdp("DECLARE.JSON1"), x->contains(x[2],"JSON 0.3.9"))
 test("JSON2", runjdp("DECLARE.JSON2"), x->contains(x[2],"JSON 0.3.7"))
 test("HDF51", runjdp("DECLARE.HDF5_1"), x->contains(x[1],"HDF5 0.7.0") && !contains(x[2],"DataFrames"))
-test("HDF52", runjdp("DECLARE.HDF5_2"), x->contains(x[1],"HDF5 0.7.0") && contains(x[2],"SHA 0.2.2"))
+test("HDF52", runjdp("DECLARE.HDF5_2"), x->contains(x[1],"HDF5 0.7.0") && contains(x[2],(VERSION < v"0.5.0" ? "SHA 0.2.2" : "staticfloat/SHA.jl.git 0.2.2")))
 test("HDF53", runjdp("DECLARE.HDF5_3"), x->contains(x[2],"HDF5.jl.git 0.7.0") && contains(x[2],"rened/HDF5"))
 ENV["DECLARE_INCLUDETEST"] = "true"
 test("HDF55_withtest", runjdp("DECLARE.HDF5_1"), x->contains(x[1],"HDF5 0.7.0"))


### PR DESCRIPTION
Fixes deprecation warnings for:

 - `--no-startup` --> `--startup-file=no`
 - `readall` --> `readstring`


TODO:
 - [x] Make sure all tests are still passing (seems to be an issue with `DECLARE.HDF5_2`)